### PR TITLE
Add :architecture attribute to server_type.rb

### DIFF
--- a/lib/hcloud/resources/server_type.rb
+++ b/lib/hcloud/resources/server_type.rb
@@ -26,6 +26,7 @@ module HCloud
     attribute :name
     attribute :description
 
+    attribute :architecture
     attribute :cores, :integer
     attribute :disk, :integer
     attribute :memory, :integer


### PR DESCRIPTION
Fixes `unknown attribute 'architecture' for HCloud::ServerType` when querying ServerTypes