### PR TITLE
Included traffic attr

### DIFF
--- a/lib/hcloud/resources/server_type.rb
+++ b/lib/hcloud/resources/server_type.rb
@@ -34,6 +34,7 @@ module HCloud
 
     attribute :cpu_type
     attribute :storage_type
+    attribute :included_traffic, :integer
 
     attribute :prices, :price, array: true, default: -> { [] }
 


### PR DESCRIPTION
Fixes `unknown attribute 'included_traffic' for HCloud::ServerType` error.