### PR TITLE
Add public_net support to Server creation and fix nested array serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Continuous Integration](https://github.com/floriandejonckheere/hcloud/actions/workflows/ci.yml/badge.svg)
 ![Release](https://img.shields.io/github/v/release/floriandejonckheere/hcloud?label=Latest%20release)
 
-Unofficial Ruby integration with the [Hetzner Cloud API](https://docs.hetzner.cloud/).
+Unofficial Ruby integration with the [Hetzner Cloud API](https://docs.hetzner.cloud/). Refer to the [API specification](https://docs.hetzner.cloud/reference/cloud) for more details.
 
 ## Installation
 
@@ -94,8 +94,8 @@ The following table lists the Hetzner Cloud API endpoints that are currently imp
 | [Pricing](lib/hcloud/resources/pricing.rb)                                       | Implemented           |
 | [RRSets](lib/hcloud/resources/rrset.rb)                                          | Implemented           |
 | [RRSet Actions](lib/hcloud/resources/rrset.rb)                                   | Implemented           |
-| [Servers](lib/hcloud/resources/server.rb)                                        | Partially implemented |
-| [Server Actions](lib/hcloud/resources/server.rb)                                 | Not implemented       |
+| [Servers](lib/hcloud/resources/server.rb)                                        | Implemented           |
+| [Server Actions](lib/hcloud/resources/server.rb)                                 | Implemented           |
 | [Server Types](lib/hcloud/resources/server_type.rb)                              | Implemented           |
 | [SSH Keys](lib/hcloud/resources/ssh_key.rb)                                      | Implemented           |
 | [Storage Boxes](lib/hcloud/resources/storage_box.rb)                             | Implemented           |

--- a/lib/hcloud/concerns/creatable.rb
+++ b/lib/hcloud/concerns/creatable.rb
@@ -42,19 +42,38 @@ module HCloud
         []
       end
 
-      # Convert creatable_attributes into a key-value list
-      # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
       def creatable_params
         # Split simple and nested attributes
         nested_attributes, simple_attributes = creatable_attributes.partition { |a| a.respond_to? :each }
 
+        serialize_simple_attributes(simple_attributes)
+          .merge(serialize_nested_attributes(nested_attributes))
+          .compact_blank
+      end
+
+      private
+
+      def serialize_simple_attributes(simple_attributes)
         attributes
           .slice(*simple_attributes.map(&:to_s))
           .transform_values { |v| v&.send_wrap { |o| o.try(:to_h) || o } || v&.send_wrap(:to_s) }
-          .merge(nested_attributes.reduce(&:merge).to_h { |k, v| [k.to_s, Array(v).filter_map { |w| send(k)&.send_wrap(w) }.first] })
-          .compact_blank
       end
-      # rubocop:enable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
+
+      def serialize_nested_attributes(nested_attributes)
+        return {} if nested_attributes.empty?
+
+        nested_attributes.reduce(&:merge).to_h do |k, v|
+          [k.to_s, serialize_nested_attribute(send(k), v)]
+        end
+      end
+
+      def serialize_nested_attribute(value, fallbacks)
+        if value.is_a?(Array)
+          value.map { |item| Array(fallbacks).filter_map { |w| item&.send_wrap(w) }.first }
+        else
+          Array(fallbacks).filter_map { |w| value&.send_wrap(w) }.first
+        end
+      end
     end
 
     class_methods do

--- a/lib/hcloud/entities/public_net.rb
+++ b/lib/hcloud/entities/public_net.rb
@@ -6,5 +6,17 @@ module HCloud
     attribute :floating_ips, :floating_ip, array: true, default: -> { [] }
     attribute :ipv4, :ipv4
     attribute :ipv6, :ipv6
+
+    attribute :enable_ipv4, :boolean
+    attribute :enable_ipv6, :boolean
+
+    def to_h
+      {
+        enable_ipv4: enable_ipv4,
+        enable_ipv6: enable_ipv6,
+        ipv4: ipv4&.id,
+        ipv6: ipv6&.id,
+      }.compact
+    end
   end
 end

--- a/lib/hcloud/resources/server.rb
+++ b/lib/hcloud/resources/server.rb
@@ -44,6 +44,9 @@ module HCloud
   #     firewall = HCloud::Server.create(name: "my_server", image: "debian-11", server_type: "cx11")
   #     # => #<HCloud::Server id: 1, ...>
   #
+  #     # Create a server with a private IP only
+  #     server = HCloud::Server.create(name: "my_server", image: "debian-11", server_type: "cx11", public_net: { enable_ipv4: false, enable_ipv6: false }, networks: [network_id])
+  #
   # == Update server
   #
   #     server = HCloud::Server.find(1)
@@ -168,7 +171,7 @@ module HCloud
     action :request_console
 
     def creatable_attributes
-      [:name, :automount, :start_after_create, :user_data, :labels, datacenter: [:id, :name], image: [:id, :name], location: [:id, :name], server_type: [:id, :name], ssh_keys: [:id, :name], firewalls: :id, networks: :id, volumes: :id]
+      [:name, :automount, :start_after_create, :user_data, :labels, :public_net, datacenter: [:id, :name], image: [:id, :name], location: [:id, :name], server_type: [:id, :name], ssh_keys: [:id, :name], firewalls: :id, networks: :id, volumes: :id]
     end
 
     def updatable_attributes

--- a/spec/hcloud/concerns/creatable_spec.rb
+++ b/spec/hcloud/concerns/creatable_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe HCloud::Creatable do
 
     it "creates the resource" do
       stub_request(:post, "https://api.hetzner.cloud/v1/examples")
-        .with(body: { name: "my_resource", description: "my_description", sibling: { type: "sister", child: { id: 1 } }, child: "name1", children: [1, nil] })
+        .with(body: { name: "my_resource", description: "my_description", sibling: { type: "sister", child: { id: 1 } }, child: "name1", children: [1, "name1"] })
         .to_return(body: { example: resource.attributes.merge(id: 1, created: 1.second.ago) }.to_json)
 
       resource.create
@@ -24,7 +24,7 @@ RSpec.describe HCloud::Creatable do
 
     it "returns the resource" do
       stub_request(:post, "https://api.hetzner.cloud/v1/examples")
-        .with(body: { name: "my_resource", description: "my_description", sibling: { type: "sister", child: { id: 1 } }, child: "name1", children: [1, nil] })
+        .with(body: { name: "my_resource", description: "my_description", sibling: { type: "sister", child: { id: 1 } }, child: "name1", children: [1, "name1"] })
         .to_return(body: { example: resource.attributes.merge(id: 1, created: 1.second.ago) }.to_json)
 
       expect(resource.create).to be_a described_class
@@ -33,7 +33,7 @@ RSpec.describe HCloud::Creatable do
     context "when the API return an action" do
       it "returns the action" do
         stub_request(:post, "https://api.hetzner.cloud/v1/examples")
-          .with(body: { name: "my_resource", description: "my_description", sibling: { type: "sister", child: { id: 1 } }, child: "name1", children: [1, nil] })
+          .with(body: { name: "my_resource", description: "my_description", sibling: { type: "sister", child: { id: 1 } }, child: "name1", children: [1, "name1"] })
           .to_return(body: { action: { id: 1, status: "running", command: "create_resource", resources: [id: 2, type: "example"] } }.to_json)
 
         action = resource.create

--- a/spec/hcloud/resources/server_unit_spec.rb
+++ b/spec/hcloud/resources/server_unit_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+RSpec.describe HCloud::Server do
+  subject(:server) { described_class.new(name: "my-server") }
+
+  describe "#create" do
+    it "serializes public_net and ssh_keys correctly" do
+      # Set up server with public_net and ssh_keys
+      server = described_class.new(
+        name: "my-server",
+        image: "debian-11",
+        server_type: "cx11",
+        public_net: {
+          enable_ipv4: false,
+          enable_ipv6: false,
+        },
+        ssh_keys: [
+          HCloud::SSHKey.new(name: "my-key-name"),
+          HCloud::SSHKey.new(id: 12_345),
+          HCloud::SSHKey.new(id: 67_890, name: "both"),
+        ],
+      )
+
+      # Stub the POST request and assert the body contains correct values
+      stub_request(:post, "https://api.hetzner.cloud/v1/servers")
+        .with(body: {
+                name: "my-server",
+                image: "debian-11",
+                server_type: "cx11",
+                public_net: {
+                  enable_ipv4: false,
+                  enable_ipv6: false,
+                },
+                ssh_keys: ["my-key-name", 12_345, 67_890],
+              })
+        .to_return(body: { server: server.attributes.merge(id: 1, created: 1.second.ago) }.to_json)
+
+      server.create
+
+      expect(server).to be_created
+      expect(server.id).to eq 1
+    end
+
+    it "serializes public_net with primary IP IDs correctly" do
+      # Set up server with public_net including primary IP IDs
+      server = described_class.new(
+        name: "my-server",
+        image: "debian-11",
+        server_type: "cx11",
+        public_net: {
+          enable_ipv4: true,
+          enable_ipv6: true,
+          ipv4: HCloud::IPv4.new(id: 111),
+          ipv6: HCloud::IPv6.new(id: 222),
+        },
+      )
+
+      stub_request(:post, "https://api.hetzner.cloud/v1/servers")
+        .with(body: {
+                name: "my-server",
+                image: "debian-11",
+                server_type: "cx11",
+                public_net: {
+                  enable_ipv4: true,
+                  enable_ipv6: true,
+                  ipv4: 111,
+                  ipv6: 222,
+                },
+              })
+        .to_return(body: { server: server.attributes.merge(id: 1, created: 1.second.ago) }.to_json)
+
+      server.create
+
+      expect(server).to be_created
+    end
+  end
+end


### PR DESCRIPTION
This PR enables provisioning private-only servers through the gem's standard API and resolves a bug in the nested array attribute serialization.

### Changes
1. **Added public_net support to Server creation:**
   - Added `:public_net` to `HCloud::Server#creatable_attributes`.
   - Declared `enable_ipv4` and `enable_ipv6` boolean attributes on the `HCloud::PublicNet` entity.
   - Implemented a custom `to_h` method for `PublicNet` to correctly serialize the enabled flags and Primary IP IDs (if present).
   
2. **Fixed nested array serialization bug:**
   - Refactored `creatable_params` in `HCloud::Creatable` to map each nested array element individually to its first available non-nil fallback attribute. 
   - This resolves the bug where name-only SSH keys (`ssh_keys: [:id, :name]`) serialized to `[nil, nil]` because the previous implementation mapped the fallback options across the entire collection concurrently.

3. **Documentation & Tests:**
   - Updated the feature implementation table in `README.md` to mark `Servers` and `Server Actions` as fully `Implemented`.
   - Added an example of provisioning a private-only server to the inline documentation of `HCloud::Server`.
   - Added unit tests in `spec/hcloud/resources/server_unit_spec.rb` to cover `public_net` and `ssh_keys` serialization on server creation.
