### PR TITLE
Fix ArgumentError when reading LoadBalancer#private_net with an attached network

### DIFF
--- a/lib/hcloud/resources/load_balancer.rb
+++ b/lib/hcloud/resources/load_balancer.rb
@@ -184,7 +184,7 @@ module HCloud
     # TODO: use only for creation
     attribute :public_interface, :boolean
 
-    attribute :private_net, :load_balancer_private_net
+    attribute :private_net, :load_balancer_private_net, array: true, default: -> { [] }
     attribute :public_net, :load_balancer_public_net
 
     attribute :services, :service, array: true, default: -> { [] }

--- a/spec/hcloud/resources/load_balancer_spec.rb
+++ b/spec/hcloud/resources/load_balancer_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe HCloud::LoadBalancer, :integration, order: :defined do
 
     expect(load_balancer.location.name).to eq "nbg1"
 
-    expect(load_balancer.private_net).to be_nil
+    expect(load_balancer.private_net).to be_empty
     expect(load_balancer.public_net).to be_enabled
 
     # TODO: create services and targets


### PR DESCRIPTION
## Summary
- `HCloud::LoadBalancer#private_net` was declared as a single-object attribute, but the API returns it as an array (`"private_net": [{"network": ..., "ip": ...}]`), so reading `.private_net` raised `ArgumentError: cannot cast value: [...] for type HCloud::LoadBalancerPrivateNet` as soon as a load balancer had a network attached.
- Fixes it the same way `Server#private_net` already handles the equally multi-valued field: `attribute :private_net, :load_balancer_private_net, array: true, default: -> { [] }`.
- No changes needed to `HCloud::LoadBalancerPrivateNet` itself — `ip`/`network` remain per-element attributes.

## Reproduction
1. Create a load balancer and attach it to a network: `lb.attach_to_network(network: network_id)`.
2. Fetch/reload it (`HCloud::LoadBalancer.where(name: ...).first`) and read `.private_net`.
3. Observe the `ArgumentError` above (fixed by this PR).

## Test plan
- [x] `bundle exec rspec` (179 examples, 0 failures)
- [x] `bundle exec rubocop` on changed files
- [x] Updated the integration spec assertion (`private_net` is now an empty array, not `nil`, when unattached) to match the corrected behavior